### PR TITLE
Allow wrapping slides into a container element

### DIFF
--- a/src/jquery.cslider.js
+++ b/src/jquery.cslider.js
@@ -26,7 +26,7 @@
     $.Slider.prototype = {
         _init: function (options) {
             this.options = $.extend(true, {}, $.Slider.defaults, options);
-            this.$slides = this.$el.children('div.da-slide');
+            this.$slides = this.$el.find('div.da-slide');
             this.slidesCount = this.$slides.length;
             this.current = this.options.current;
             if (this.current < 0 || this.current >= this.slidesCount) {

--- a/src/jquery.cslider.js
+++ b/src/jquery.cslider.js
@@ -53,7 +53,7 @@
             }
         },
         _navigate: function (page, dir) {
-            var $current = this.$slides.eq(this.current), $next, _self = this;
+            var $current = this.$slides.eq(this.current), $next;
             if (this.current === page || this.isAnimating) return false;
             this.isAnimating = true;
             // check dir
@@ -112,11 +112,11 @@
         },
         _loadEvents: function () {
             var _self = this;
-            this.$pages.on('click.cslider', function (event) {
+            this.$pages.on('click.cslider', function () {
                 _self.page($(this).index());
                 return false;
             });
-            this.$navNext.on('click.cslider', function (event) {
+            this.$navNext.on('click.cslider', function () {
                 if (_self.options.autoplay) {
                     clearTimeout(_self.slideshow);
                     _self.options.autoplay = false;
@@ -125,7 +125,7 @@
                 _self._navigate(page, 'next');
                 return false;
             });
-            this.$navPrev.on('click.cslider', function (event) {
+            this.$navPrev.on('click.cslider', function () {
                 if (_self.options.autoplay) {
                     clearTimeout(_self.slideshow);
                     _self.options.autoplay = false;

--- a/src/style.css
+++ b/src/style.css
@@ -91,7 +91,6 @@
     left: 0;
     bottom: 20px;
     z-index: 2000;
-
 }
 
 .da-dots span {
@@ -116,7 +115,7 @@
     left: 2px;
     border-radius: 50%;
     background: rgb(255, 255, 255);
-    background: linear-gradient(top, rgba(255, 255, 255, 1) 0%, rgba(246, 246, 246, 1) 47%, rgba(237, 237, 237, 1) 100%);
+    background: linear-gradient(to top, rgba(255, 255, 255, 1) 0%, rgba(246, 246, 246, 1) 47%, rgba(237, 237, 237, 1) 100%);
 }
 
 .da-arrows span {


### PR DESCRIPTION
+ Currently slides need to be direct children of the most outer slider element.
+ This change allows them to be wrapped into further elements, e.g. a container to limit the content width while keeping the background at full width.
+ The navigation arrows are already found with "find" and the navigation dots are centered anyway, hence this one change is all that is needed.